### PR TITLE
fix: Setting timeout on testnet CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
   testnet:
     runs-on: ubuntu-latest
     needs: emulator
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR adds the `timeout-minutes` directive to the testnet job description, to ensure that we're not burning through our GitHub Actions minutes