### PR TITLE
WIP: fix(deployment): switching to remove/add instead of update__experimental

### DIFF
--- a/lib/go/scripts/remove.go
+++ b/lib/go/scripts/remove.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/flow-usdc/flow-usdc/deploy"
+	"github.com/onflow/flow-go-sdk/client"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	ctx := context.Background()
+	flowClient, err := client.New(os.Getenv("RPC_ADDRESS"), grpc.WithInsecure())
+	if err != nil {
+		panic(err)
+	}
+
+	ownerAddress := os.Getenv("TOKEN_ACCOUNT_ADDRESS")
+	skFT := os.Getenv("TOKEN_ACCOUNT_KEYS")
+
+	result, err := deploy.RemoveUSDCContract(ctx, flowClient, ownerAddress, skFT)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(result.Events)
+}

--- a/lib/go/test.sh
+++ b/lib/go/test.sh
@@ -48,7 +48,11 @@ flow project deploy --network="$NETWORK" --update
 # NOW we switch to the go folder, where commands _can_ be run in place.
 cd lib/go;
 
+if [ "${NETWORK}" == "testnet" ]; then
+  go run scripts/remove.go
+fi
 go run scripts/deploy.go
+
 go test ./deploy -v
 
 NEW_VAULTED_ACCOUNT_SEED=$(hexdump -n 16 -e '4/4 "%08X" 1 "\n"' /dev/random)
@@ -57,7 +61,7 @@ NEW_VAULTED_ACCOUNT_PK=$(flow keys generate --seed="$NEW_VAULTED_ACCOUNT_SEED" -
 NEW_VAULTED_ACCOUNT_ADDRESS=$(flow accounts create --network="$NETWORK" --key="$NEW_VAULTED_ACCOUNT_PK" --signer="$SIGNER" -o inline --filter=Address)
 
 if [ "${NETWORK}" == "testnet" ]; then
-  flow transactions send ./transactions/transfer_flow_tokens_testnet.cdc \
+  flow transactions send ../../transactions/transfer_flow_tokens_testnet.cdc \
     -f "$FLOW_CONFIG_PATH" \
     --arg=UFix64:0.001 \
     --arg=Address:0x"$NEW_VAULTED_ACCOUNT_ADDRESS" \

--- a/transactions/deploy_contract_with_auth.cdc
+++ b/transactions/deploy_contract_with_auth.cdc
@@ -5,13 +5,6 @@
 //
 transaction(contractName: String, code: String) {
     prepare(owner: AuthAccount) {
-        let existingContract = owner.contracts.get(name: contractName)
-
-        if (existingContract == nil) {
-            owner.contracts.add(name: contractName, code: code.decodeHex(), owner)
-        } else {
-            owner.contracts.remove(name: contractName)
-            owner.contracts.add(name: contractName, code: code.decodeHex(), owner)
-        }
+        owner.contracts.add(name: contractName, code: code.decodeHex(), owner)
     }
 }

--- a/transactions/remove_contract_with_auth.cdc
+++ b/transactions/remove_contract_with_auth.cdc
@@ -1,0 +1,27 @@
+// This transactions removes the USDC contract
+
+import USDC from 0x{{.USDCToken}}
+
+transaction(contractName: String) {
+    prepare(owner: AuthAccount) {
+        owner.unlink(USDC.MasterMinterPrivPath)
+        owner.unlink(USDC.BlockListExecutorPrivPath)
+        owner.unlink(USDC.PauseExecutorPrivPath)
+
+        destroy owner.load<@USDC.MasterMinter>(from: USDC.MasterMinterStoragePath)
+        destroy owner.load<@USDC.BlockListExecutor>(from: USDC.BlockListExecutorStoragePath)
+        destroy owner.load<@USDC.PauseExecutor>(from: /storage/UsdcPauseExec)
+        destroy owner.load<@USDC.Pauser>(from: /storage/UsdcPauseExec)
+
+        owner.unlink(USDC.OwnerPrivPath)
+
+        destroy owner.load<@USDC.Owner>(from: USDC.OwnerStoragePath)
+
+        owner.unlink(/public/UsdcReceiver)
+        owner.unlink(/public/UsdcBalance)
+
+        destroy owner.load<@USDC.Vault>(from: /storage/UsdcVault)
+
+        owner.contracts.remove(name: contractName)
+    }
+}


### PR DESCRIPTION
This PR swaps out `update_experimental` for now, favoring `remove`/`add`.

Note: This will wipe out all contract state but for now it's fine since it's testnet.

At some point we need to review and discuss https://docs.onflow.org/cadence/language/contract-updatability/ and plan our code around it (making it more upgrade-compatible, if possible)

Fixes #24 