### PR TITLE
degrade(ci): soft-disable testnet job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
         run: make test
 
   testnet:
+    if: false
     runs-on: ubuntu-latest
     needs: emulator
     timeout-minutes: 10


### PR DESCRIPTION
This PR disables the `testnet` job in CI, related to #24 