### PR TITLE
tests: incr + decr mint allowance

### DIFF
--- a/contracts/FiatTokenInterface.cdc
+++ b/contracts/FiatTokenInterface.cdc
@@ -26,8 +26,15 @@ pub contract interface FiatTokenInterface {
 
     pub let OwnerStoragePath: StoragePath;
     pub let OwnerPrivPath: PrivatePath;
+
     pub let MasterMinterStoragePath: StoragePath;
     pub let MasterMinterPrivPath: PrivatePath;
+
+    pub let MinterControllerStoragePath: StoragePath;
+    pub let MinterControllerUUIDPubPath: PublicPath;
+
+    pub let MinterStoragePath: StoragePath;
+    pub let MinterUUIDPubPath: PublicPath;
     
     // ===== Pause state and events =====
     /// Contract is paused if `paused` is `true`
@@ -105,14 +112,6 @@ pub contract interface FiatTokenInterface {
     ///
     /// The event that is emitted when minter controller has removed the minter 
     pub event MinterRemoved(controller: UInt64, minter: UInt64);
-    /// MinterAllowanceIncreased
-    ///
-    /// The event that is emitted when minter controller has increase the minter's allowance
-    pub event MinterAllowanceIncreased(minter: UInt64, newAllowance: UFix64);
-    /// MinterAllowanceDecreased
-    ///
-    /// The event that is emitted when minter controller has decrease the minter's allowance
-    pub event MinterAllowanceDecreased(minter: UInt64, newAllowance: UFix64);
     /// ControllerConfigured
     ///
     /// The event that is emitted when master minter has set the mint controller's minter 
@@ -143,8 +142,8 @@ pub contract interface FiatTokenInterface {
         ///
         /// Function that updates existing minter restrictions
         pub fun configureMinterAllowance(allowance: UFix64);
-        pub fun incrementMinterAllowance(amount: UFix64);
-        pub fun decrementMinterAllowance(amount: UFix64);
+        pub fun increaseMinterAllowance(increment: UFix64);
+        pub fun decreaseMinterAllowance(decrement: UFix64);
         pub fun removeMinter();
     }
 

--- a/lib/go/mint/mintController_test.go
+++ b/lib/go/mint/mintController_test.go
@@ -55,6 +55,44 @@ func TestController_ConfigureMinterAllowance(t *testing.T) {
 	assert.Equal(t, expected, allowance)
 }
 
+func TestController_IncreaseMinterAllowance(t *testing.T) {
+	g := gwtf.NewGoWithTheFlow("../../../flow.json")
+
+	minter, err := GetMinterUUID(g, "minter")
+	assert.NoError(t, err)
+	initAllowance, err := GetMinterAllowance(g, minter)
+	assert.NoError(t, err)
+
+	var allowanceIncr = "500.0"
+	err = IncreaseOrDecreaseMinterAllowance(g, "minterController1", allowanceIncr, 1)
+	assert.NoError(t, err)
+
+	postAllowance, err := GetMinterAllowance(g, minter)
+	assert.NoError(t, err)
+	expectedDelta, err := cadence.NewUFix64(allowanceIncr)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDelta, postAllowance-initAllowance)
+}
+
+func TestController_DecreaseMinterAllowance(t *testing.T) {
+	g := gwtf.NewGoWithTheFlow("../../../flow.json")
+
+	minter, err := GetMinterUUID(g, "minter")
+	assert.NoError(t, err)
+	initAllowance, err := GetMinterAllowance(g, minter)
+	assert.NoError(t, err)
+
+	var allowanceDecr = "500.0"
+	err = IncreaseOrDecreaseMinterAllowance(g, "minterController1", allowanceDecr, 0)
+	assert.NoError(t, err)
+
+	postAllowance, err := GetMinterAllowance(g, minter)
+	assert.NoError(t, err)
+	expectedDelta, err := cadence.NewUFix64(allowanceDecr)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDelta, initAllowance-postAllowance)
+}
+
 func TestController_RemoveMinter(t *testing.T) {
 	g := gwtf.NewGoWithTheFlow("../../../flow.json")
 
@@ -118,7 +156,7 @@ func TestController_MultipleControllerCanConfigureOneMinter(t *testing.T) {
 	assert.Equal(t, expectedController2, allowance)
 }
 
-func TestController_RemoveController(t *testing.T) {
+func TestController_MasterMinterRemoveController(t *testing.T) {
 	g := gwtf.NewGoWithTheFlow("../../../flow.json")
 	minterController2, err := GetMinterControllerUUID(g, "minterController2")
 	assert.NoError(t, err)

--- a/lib/go/mint/minterController.go
+++ b/lib/go/mint/minterController.go
@@ -67,3 +67,24 @@ func RemoveMinter(
 		RunPrintEventsFull()
 	return
 }
+
+func IncreaseOrDecreaseMinterAllowance(
+	g *gwtf.GoWithTheFlow,
+	minterControllerAcct string,
+	absDelta string,
+	inc uint,
+) (err error) {
+	var txFilename string
+	if inc == 1 {
+		txFilename = "../../../transactions/mint/increase_minter_allowance.cdc"
+	} else {
+		txFilename = "../../../transactions/mint/decrease_minter_allowance.cdc"
+	}
+
+	txScript := util.ParseCadenceTemplate(txFilename)
+	err = g.TransactionFromFile(txFilename, txScript).
+		SignProposeAndPayAs(minterControllerAcct).
+		UFix64Argument(absDelta).
+		RunPrintEventsFull()
+	return
+}

--- a/transactions/mint/decrease_minter_allowance.cdc
+++ b/transactions/mint/decrease_minter_allowance.cdc
@@ -1,0 +1,13 @@
+// MinterController uses this to decrease minter allowance 
+
+import FiatToken from 0x{{.FiatToken}}
+import FiatTokenInterface from 0x{{.FiatTokenInterface}}
+
+transaction (amount: UFix64) {
+    prepare(minterController: AuthAccount) {
+        let mc = minterController.borrow<&FiatToken.MinterController>(from: FiatToken.MinterControllerStoragePath) 
+            ?? panic ("no minter controller resource avaialble");
+
+        mc.decreaseMinterAllowance(decrement: amount);
+    }
+}

--- a/transactions/mint/increase_minter_allowance.cdc
+++ b/transactions/mint/increase_minter_allowance.cdc
@@ -1,0 +1,13 @@
+// MinterController uses this to increase minter allowance 
+
+import FiatToken from 0x{{.FiatToken}}
+import FiatTokenInterface from 0x{{.FiatTokenInterface}}
+
+transaction (amount: UFix64) {
+    prepare(minterController: AuthAccount) {
+        let mc = minterController.borrow<&FiatToken.MinterController>(from: FiatToken.MinterControllerStoragePath) 
+            ?? panic ("no minter controller resource avaialble");
+
+        mc.increaseMinterAllowance(increment: amount);
+    }
+}


### PR DESCRIPTION
Another continue with Minting features

- [x] create minter
- [x] create minter controller
- [x] configure minter controller
- [x] remove minter controller
- [x] configure minter
- [x] removed minter controllers cannot configure minter
- [x] multiple minter controllers can configure same minter
- [x] minter removal stops minting / burning
- [x] minter allowance increase / decrease
- [x] minter cannot mint above allowance
- [x] no minting / burning for blocklisted resource
- [x] no minting / burning for paused resources
- [x] minter without controller config cannot mint
- N/A minter restriction implementations (expiration, fixed recv addr)